### PR TITLE
Fixes parsing error (allowQP=True)

### DIFF
--- a/Contact.py
+++ b/Contact.py
@@ -24,7 +24,7 @@ class ContactList:
                             self.append(vobject.readOne(vcf_file))
                 else:  # this way counting number of records in a file
                     with open(vcf, mode='r', encoding='utf-8') as vcf_file:
-                        for v in vobject.readComponents(vcf_file):
+                        for v in vobject.readComponents(vcf_file, allowQP=True):
                             self.counter += 1
                             self.append(v)
         except Exception as e:
@@ -93,7 +93,7 @@ class ContactList:
 
 def open_vcf(location, debug=True):
     with open(location, mode='r', encoding='utf-8') as vcf_file:
-        for v in vobject.readComponents(vcf_file):
+        for v in vobject.readComponents(vcf_file, allowQP=True):
             if debug:
                 print(v.serialize())
                 print('*'*20)


### PR DESCRIPTION
Error opening my contacts file

```
/home/qa/vcf_editor/venv/bin/python /home/qa/vcf_editor/main.py 
using small tkinter (windows way)
... no contacts library loaded
error: At line 19: Failed to parse line: =D0=BD=D0=B8=D1=8F;;;
```

Fix I found on [stackoverflow](https://ru.stackoverflow.com/questions/1599809)

## Summary by Sourcery

Bug Fixes:
- Fix parsing error in VCF file by enabling quoted-printable (QP) decoding.