### PR TITLE
Fix address

### DIFF
--- a/Contact.py
+++ b/Contact.py
@@ -39,11 +39,11 @@ def parse_vcard(vcard: vobject) -> dict:
     # Extract addresses
     for adr in vcard.contents.get('adr', []):
         # Join each component's lines into a single line
-        street = ' '.join(adr.value.street)
-        city = ' '.join(adr.value.city)
-        region = ' '.join(adr.value.region)
-        code = ' '.join(adr.value.code)
-        country = ' '.join(adr.value.country)
+        street = ''.join(adr.value.street)
+        city = ''.join(adr.value.city)
+        region = ''.join(adr.value.region)
+        code = ''.join(adr.value.code)
+        country = ''.join(adr.value.country)
         # Join all components into a single address string
         address = ', '.join(filter(None, [street, city, region, code, country]))
         contact['addresses'].append(address)


### PR DESCRIPTION
Addresses that were filled with spaces (empty line) after each letter without a comma:
```
{Ж у к о в а   1   к в .   1 2 3} {З е л е н ы й   л о г   1 2 \ 3   к в .   4}
```

Fixed it, now it looks like this:
```
{Жукова 1 кв. 123} {Зеленый лог 12\3 кв. 4}
```

But I didn't understand at what stage the curly brackets appear and how to remove them.

## Summary by Sourcery

Bug Fixes:
- Fix address formatting by removing spaces between characters in address components.