### PR TITLE
Up-to-date vobject links, library updates and addition of test contact file

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Prepare environment:
 python -m venv venv
 source ./venv/bin/activate
 venv/Script/activate #windows way
+sudo apt install python3-tk
 pip install -r requirements.txt
 ```
 
@@ -36,8 +37,8 @@ https://www.tutorialkart.com/python/tkinter/entry/
 
 ### VCF
 
-- [Vobject github source](https://github.com/eventable/vobject)
-- [Vobject documentation](http://eventable.github.io/vobject/)
+- [Vobject github source](https://github.com/py-vobject/vobject/)
+- [Vobject documentation](https://py-vobject.github.io/)
 - [Vobject usage old](http://vobject.skyhouseconsulting.com/usage.html)
 - [Vobject vcard definition](https://github.com/eventable/vobject/blob/master/vobject/vcard.py)
 - [VCF Fields Definition (N section)](https://datatracker.ietf.org/doc/html/rfc6350#section-6.2.2)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 python-dateutil==2.9.0.post0
-six==1.16.0
+six==1.17.0
 Unidecode==1.3.8
-vobject==0.9.8
+vobject==0.9.9

--- a/sample/contacts_ru_v3.0.vcf
+++ b/sample/contacts_ru_v3.0.vcf
@@ -1,0 +1,30 @@
+BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Apple Inc.//Mac OS X 10.12.6//EN
+N:Алексеева Вагда Фаридовна;;;;
+FN:Алексеева Вагда Фаридовна
+EMAIL;type=INTERNET;type=WORK;type=pref:v.alekseeva@example.org
+UID:01cac8f2-f67e-45bb-984d-1c817f9ab940
+X-ABUID:01CAC8F2-F67E-45BB-984D-1C817F9AB940:ABPerson
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Apple Inc.//Mac OS X 10.12.6//EN
+N:;Иванов Николай Петрович;;;
+EMAIL;type=INTERNET;type=WORK;type=pref:n.ivanov@example.org
+BDAY:1986-07-12
+X-ABShowAs:COMPANY
+CATEGORIES:DEV
+UID:3012c7fc-0924-4531-a9c2-03ab051434e6
+X-ABUID:A3D21F31-1C5B-4D26-838C-91C19B8395A1:ABPerson
+END:VCARD
+BEGIN:VCARD
+VERSION:3.0
+PRODID:-//Apple Inc.//Mac OS X 10.12.6//EN
+N:Ермакова Алия;;;;
+EMAIL;type=INTERNET;type=WORK;type=pref:a.ermakova@example.org
+BDAY:1990-01-28
+X-ABShowAs:COMPANY
+UID:fa2b64d4-bf6f-4712-96f3-2ba775745eb6
+X-ABUID:534E6569-2FF8-401E-A325-5FBCE8EBAA3D:ABPerson
+END:VCARD


### PR DESCRIPTION
Updated links to `vobject`.
https://github.com/skarim/vobject - abandoned since 2018
https://github.com/py-vobject/vobject - the current fork that is currently being developed
https://pypi.org/project/vobject - refers to a new fork (py-vobject/vobject)

A lot of things in `Resources` seem out of date, is it really necessary?

Updated the library versions at once.

Added a test file of Russian-language contacts.

Later I will add another one where `allowQP=True` is required.

By the way, are there any wishes for test contacts, so that they would be more useful and diverse?

## Summary by Sourcery

Update the vobject dependency to the latest version and add a Russian-language test contact file.  Update the links to the vobject library to point to the correct repository.  Add python-tk to the list of dependencies.

Documentation:
- Update the links to the vobject library.

Tests:
- Add a Russian-language test contact file.